### PR TITLE
Add R120 and canFDCapable fields to canbus.cpp

### DIFF
--- a/connections/canbus.cpp
+++ b/connections/canbus.cpp
@@ -47,6 +47,9 @@ void CANBus::setCanFD(bool mode){
     canFD = mode;
 }
 
+
+
+
 int CANBus::getSpeed() const {
     return speed;
 }
@@ -74,6 +77,27 @@ bool CANBus::isActive() const {
 
 bool CANBus::isCanFD() const {
     return canFD;
+}
+
+
+
+void CANBus::setCanFDCapable(bool val) {
+	canFDCapable = val;
+}
+void CANBus::setR120Swithcable(bool val) {
+	r120Switchable = val;
+}
+void CANBus::setR120(bool val) {
+	r120 = val;
+}
+bool CANBus::isCanFDCapable(void) {
+	return canFDCapable;
+}
+bool CANBus::isR120Switchable(void) {
+	return r120Switchable
+}
+bool CANBus::isR120On(void) {
+	return r120;
 }
 
 

--- a/connections/canbus.h
+++ b/connections/canbus.h
@@ -14,6 +14,11 @@ class CANBus
 
     friend QDataStream& operator<<(QDataStream & pStream, const CANBus& pCanBus);
     friend QDataStream& operator>>(QDataStream & pStream, CANBus& pCanBus);
+
+	bool canFDCapable;		// does this CANBUS support CANFD?
+	bool r120Switchable;	// does this CANBUS support programmable switching 120R termination resistor?
+	bool r120;				// doest 120R terminator is ON?
+
 public:
     CANBus();
 
@@ -32,6 +37,14 @@ public:
     bool isSingleWire() const;
     bool isActive() const;
     bool isCanFD() const;
+
+	void setCanFDCapable(bool val);
+	void setR120Swithcable(bool val);
+	void setR120(bool val);
+
+	bool isCanFDCapable(void) const;
+	bool isR120Switchable(void) const;
+	bool isR120On(void) const;
 };
 
 QDataStream& operator<<(QDataStream & pStream, const CANBus& pCanBus);


### PR DESCRIPTION
Creating canbus.cpp more universal. I creating 2-port CAN sniffer whith is able to programically connect / disconnect 120R terminators on CAN bus. Unfortunetly original SavvyCAN can't support this functions.